### PR TITLE
Remove StatusProblemConverter check from StatusProblemMatchers

### DIFF
--- a/transport/http/problems.go
+++ b/transport/http/problems.go
@@ -137,10 +137,6 @@ func (c problemConverter) NewProblem(ctx context.Context, err error) problems.Pr
 			}
 
 			if statusMatcher, ok := matcher.(StatusProblemMatcher); ok {
-				if converter, ok := statusMatcher.(StatusProblemConverter); ok {
-					return converter.NewStatusProblem(ctx, statusMatcher.Status(), err)
-				}
-
 				return c.statusProblemConverter.NewStatusProblem(ctx, statusMatcher.Status(), err)
 			}
 

--- a/transport/http/problems_test.go
+++ b/transport/http/problems_test.go
@@ -71,27 +71,6 @@ func (s statusMatcherConverterStub) NewProblem(_ context.Context, _ error) probl
 	return problems.NewDetailedProblem(http.StatusBadRequest, "custom error")
 }
 
-type statusMatcherStatusConverterStub struct {
-	err    error
-	status int
-}
-
-func (s statusMatcherStatusConverterStub) MatchError(err error) bool {
-	return s.err == err
-}
-
-func (s statusMatcherStatusConverterStub) Status() int {
-	return s.status
-}
-
-func (s statusMatcherStatusConverterStub) NewStatusProblem(
-	_ context.Context,
-	status int,
-	_ error,
-) problems.StatusProblem {
-	return problems.NewDetailedProblem(status, "custom status error")
-}
-
 func testProblemEquals(t *testing.T, problem *problems.DefaultProblem, status int, detail string) {
 	t.Helper()
 
@@ -155,18 +134,6 @@ func TestProblemConverter(t *testing.T) {
 				},
 				status: http.StatusBadRequest,
 				detail: "custom error",
-			},
-			{
-				config: ProblemConverterConfig{
-					Matchers: []ProblemMatcher{
-						statusMatcherStatusConverterStub{
-							err:    err,
-							status: http.StatusNotFound,
-						},
-					},
-				},
-				status: http.StatusNotFound,
-				detail: "custom status error",
 			},
 			{
 				config: ProblemConverterConfig{


### PR DESCRIPTION
StatusProblemMatchers are already aware of the status code,
so they can just implement ProblemConverter if they need a custom problem conversion logic.